### PR TITLE
Qgerrit better filtering

### DIFF
--- a/scripts/qgerrit
+++ b/scripts/qgerrit
@@ -92,11 +92,29 @@ def print_wrapped(text):
 
 def _get_date(k, row):
     v = _get_key(k, row)
-    if not v:
-        return ''
     try:
-        dt = datetime.fromtimestamp(int(v))
-        return dt.strftime('%I:%M %p %m/%d/%y')
+        now = datetime.now()
+        then = datetime.fromtimestamp(int(v))
+        delta = now - then
+        hours = delta.seconds / (60 * 60)
+        mins = delta.seconds / 60
+
+        if delta.days == 1:
+            return "%d day" % delta.days
+        elif delta.days > 1:
+            return "%d days" % delta.days
+        elif hours == 1:
+            return "%d hour" % hours
+        elif hours > 1:
+            return "%d hours" % hours
+        elif mins == 1:
+            return "%d min" % mins
+        elif mins > 1:
+            return "%d mins" % mins
+        else:
+            return "just now"
+        
+        return str(delta)
     except (TypeError, ValueError):
         return ''
 


### PR DESCRIPTION
The qgerrit script had awesome potential for improving my productivity, so I've done work to add a wide range of features to it

For my needs, I've always wanted to be able to query gerrit based on file paths changed, and approval flags, but you can't do that with its query language. Fortunately the info can be added to the JSON data, allowing post-processing. So with this set of patches you can now do this

$ qgerrit -f url -f subject:100 -f approvals -f lastUpdated -f createdOn -p openstack/nova nova/virt/libvirt
+------------------------------------+-----------------------------------------------------------------------+----------+----------+---------------------+
| URL                                | Subject                                                               | Created  | Updated  | Approvals           |
+------------------------------------+-----------------------------------------------------------------------+----------+----------+---------------------+
| https://review.openstack.org/33409 | Adding image multiple location support                                | 127 days | 17 hours | v=1 c=-1,1          |
| https://review.openstack.org/35018 | libvirt: Handle empty context on hard_reboot                          | 115 days | 2 days   | v=-1,1 c=-1,-1      |
| https://review.openstack.org/35303 | Stop, Rescue, and Delete should give guest a chance to shutdown       | 112 days | 1 hour   | v=1,1 c=-1          |
| https://review.openstack.org/35760 | Added monitor (e.g. CPU) to monitor and collect data                  | 110 days | 18 hours | v=1,1 c=-1,-1       |
| https://review.openstack.org/39929 | Port to oslo.messaging                                                | 82 days  | 7 hours  | v=1,1               |
| https://review.openstack.org/43984 | Call baselineCPU for full feature list                                | 56 days  | 1 day    | v=1,1 c=-1,1,1,1    |
| https://review.openstack.org/44359 | Wait for files to be accessible when migrating                        | 54 days  | 2 days   | v=1 c=1,1,1         |
| https://review.openstack.org/45914 | libvirt: Allow delete to complete when a volume disconnect fails      | 42 days  | 25 mins  | v=-1,1              |
| https://review.openstack.org/45993 | Remove multipath mapping device descriptor                            | 42 days  | 4 hours  | v=1,1 c=-1          |
| https://review.openstack.org/46055 | Remove dup of LibvirtISCSIVolumeDriver in LibvirtISERVolumeDriver     | 42 days  | 18 hours | v=1,1 c=2           |
| https://review.openstack.org/48246 | Disconnect from iSCSI volume sessions after live migration            | 28 days  | 5 days   | v=1                 |
| https://review.openstack.org/48362 | Fixing ephemeral disk creation.                                       | 27 days  | 15 hours | v=1,1 c=2           |
| https://review.openstack.org/49329 | Add unsafe flag to libvirt live migration call.                       | 21 days  | 6 days   | v=1,1 c=-1,-1,1,1,1 |
| https://review.openstack.org/50857 | Apply six for metaclass                                               | 13 days  | 6 hours  | v=1,1               |
| https://review.openstack.org/51193 | clean up numeric expressions with byte constants                      | 12 days  | 9 hours  | v=1                 |
| https://review.openstack.org/51282 | nova.exception does not have a ProcessExecutionError                  | 11 days  | 21 hours | v=1,1               |
| https://review.openstack.org/51287 | Remove vim header from from nova/virt                                 | 11 days  | 2 days   | v=1,1 c=-1,-1       |
| https://review.openstack.org/51718 | libvirt: Fix spurious backing file existence check.                   | 8 days   | 5 days   | v=1 c=1             |
| https://review.openstack.org/52184 | Reply with a meaningful exception, when libvirt connection is broken. | 6 days   | 15 hours | v=1,1 c=2           |
| https://review.openstack.org/52189 | Disable nova-compute on libvirt connectivty exceptions                | 6 days   | 6 hours  | v=-1                |
| https://review.openstack.org/52363 | Remove unnecessary steps for cold snapshots                           | 6 days   | 40 mins  | v=1,1 c=-1          |
| https://review.openstack.org/52401 | make libvirt driver get_connection thread-safe                        | 5 days   | 3 hours  | v=1,1               |
| https://review.openstack.org/52581 | Add context as parameter for resume                                   | 5 days   | 2 days   | v=1,1,1 c=1,1       |
| https://review.openstack.org/52777 | Optimize libvirt live migration workflow at source                    | 3 days   | 1 day    | v=1,1               |
| https://review.openstack.org/52807 | Create image again when resize revert a VM with image type as LVM     | 3 days   | 3 days   | v=1,1               |
| https://review.openstack.org/53069 | Fix lxc rootfs attached two devices in some action                    | 1 day    | 1 day    | v=1,1               |
+------------------------------------+-----------------------------------------------------------------------+----------+----------+---------------------+
