### PR TITLE
Set default approval value

### DIFF
--- a/scripts/qgerrit
+++ b/scripts/qgerrit
@@ -228,7 +228,10 @@ def matches_approval(result, approval):
     except (KeyError, TypeError):
         approvals = []
 
-    got = {}
+    got = {
+        'c': 0,
+        'v': 0,
+    }
     for approval in approvals:
         got_type = approval["type"][0:1].lower()
         got_val = int(approval["value"])


### PR DESCRIPTION
Previously support for filtering on approval value was
added, eg

 qgerrit -a c1

would show all patches with positive code review. ie all
review comments were +1 or more, so excluding any patches
with negative reviews.

Conceptually

  qgerrit -a c0

should show any patches with no negative code review. The
absence of any code review should have been treated as
having value 0, but since that isn't visible in the gerrit
json output, we lost all patches without review.

The fix is to simply set a default value of 0 before
parsing the json output.

Signed-off-by: Daniel P. Berrange berrange@redhat.com
