### PR TITLE
Add command line options for specifying hostname and port of the Gerrit instance

### DIFF
--- a/scripts/qgerrit
+++ b/scripts/qgerrit
@@ -118,6 +118,9 @@ def get_key(k, row):
     v = row.get(k)
     if v is None:
         return ""
+
+    if isinstance(v, unicode):
+        v = v.encode('utf8')
     return str(v)
 
 


### PR DESCRIPTION
Just the minimal change required to allow use of the script with another gerrit instance. The script if used as today should not change its behavior and default to the original OpenStack hostname and port.

Also fix work with Unicode non-ASCII values.

Signed-off-by: Matěj Cepl mcepl@redhat.com
