### PR TITLE
Update default status url for zuul v3 endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ urwid_ and the requests_ libraries):
     Options:
       -h, --help            show this help message and exit
       -s URL, --server=URL  zuul server [default:
-                            http://zuul.openstack.org/status.json]
+                            http://zuul.openstack.org/status]
       --split-screens=SCREENS
                             split screen count [default: 3]
       -p PIPELINE, --pipeline=PIPELINE

--- a/scripts/czuul
+++ b/scripts/czuul
@@ -37,7 +37,7 @@ import urwid
 LOG = logging.getLogger(__name__)
 
 ### DEFAULT SETTINGS
-ZUUL_URL = 'http://zuul.openstack.org/status.json'
+ZUUL_URL = 'http://zuul.openstack.org/status'
 ZUUL_FREQ = 30
 ZUUL_MIN_FREQ = 5
 ALARM_FREQ = 0.5


### PR DESCRIPTION
The .json suffixes are going away.

Depends-On: https://review.openstack.org/545942